### PR TITLE
Animation: hybrid RL + animation controller and MuJoCo harness (workstream C)

### DIFF
--- a/animation/runtime/README.md
+++ b/animation/runtime/README.md
@@ -1,0 +1,14 @@
+# Hybrid animation runtime
+
+`HybridController` is a transport-independent 50 Hz controller. Construct it with
+an optional `WalkPolicy`, call `set_mode(RobotMode.HYBRID_WALK)`, add clips with
+`play()` or `play_additive()`, then call `step(dt, (vx, vy, wz), measured_obs)`.
+It returns canonical 16-joint targets suitable for either MuJoCo or hardware.
+
+The order is deliberate: measured state enters the RL policy, its raw action
+becomes base targets, animation layers mix downstream, leg authority is reduced
+as commanded speed rises, and the safety limiter runs last. The policy's
+`previous_action` is always its own raw action, never blended animation targets;
+feeding blended targets back changes the policy's perceived command history and
+can destabilize walking. Dock mode disables all leg animation authority,
+including the full dock transition.

--- a/animation/runtime/__init__.py
+++ b/animation/runtime/__init__.py
@@ -1,0 +1,15 @@
+"""Runtime glue for safely combining gait policies and duck animations."""
+
+from .gait import GaitPhaseTracker, leg_animation_gain
+from .hybrid_controller import HybridController
+from .modes import ModeStateMachine, RobotMode
+from .policy import WalkPolicy
+
+__all__ = [
+    "GaitPhaseTracker",
+    "HybridController",
+    "ModeStateMachine",
+    "RobotMode",
+    "WalkPolicy",
+    "leg_animation_gain",
+]

--- a/animation/runtime/gait.py
+++ b/animation/runtime/gait.py
@@ -1,0 +1,75 @@
+"""Gait phase and animation authority derived from velocity commands."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import numpy as np
+
+from .modes import RobotMode
+
+
+def _speed(commanded_velocity: Sequence[float]) -> float:
+    velocity = np.asarray(commanded_velocity, dtype=float)
+    if velocity.shape != (3,):
+        raise ValueError("commanded_velocity must contain (vx, vy, wz)")
+    return float(np.linalg.norm(velocity))
+
+
+def leg_animation_gain(
+    mode: RobotMode,
+    commanded_velocity: Sequence[float],
+    *,
+    floor: float = 0.15,
+    full_authority_speed: float = 0.05,
+    high_speed: float = 0.4,
+) -> float:
+    """Return safe animation authority for leg channels.
+
+    Large leg offsets while walking fast will tip the duck over, so leg
+    animation authority must shrink as speed rises.
+    """
+    if not 0.0 <= floor <= 1.0:
+        raise ValueError("floor must be in [0, 1]")
+    if high_speed <= full_authority_speed:
+        raise ValueError("high_speed must exceed full_authority_speed")
+    if mode in {RobotMode.IDLE, RobotMode.STAND, RobotMode.HYBRID_STAND}:
+        return 1.0
+    speed = _speed(commanded_velocity)
+    if speed <= full_authority_speed:
+        return 1.0
+    fraction = min(1.0, (speed - full_authority_speed) / (high_speed - full_authority_speed))
+    # Smoothstep makes the handoff to the gait policy gradual.
+    smooth = fraction * fraction * (3.0 - 2.0 * fraction)
+    return float(1.0 - (1.0 - floor) * smooth)
+
+
+class GaitPhaseTracker:
+    def __init__(
+        self,
+        gait_frequency: float = 1.25,
+        stationary_threshold: float = 0.05,
+        debounce_window: float = 0.3,
+    ) -> None:
+        if gait_frequency <= 0 or stationary_threshold < 0 or debounce_window < 0:
+            raise ValueError("Invalid gait tracker configuration")
+        self.gait_frequency = float(gait_frequency)
+        self.stationary_threshold = float(stationary_threshold)
+        self.debounce_window = float(debounce_window)
+        self.phase = 0.0
+        self._stationary_elapsed = 0.0
+
+    @property
+    def is_stationary(self) -> bool:
+        return self._stationary_elapsed >= self.debounce_window
+
+    def update(self, dt: float, commanded_velocity: Sequence[float]) -> float:
+        if dt < 0:
+            raise ValueError("dt must be non-negative")
+        speed = _speed(commanded_velocity)
+        self.phase = math.fmod(self.phase + dt * self.gait_frequency, 1.0)
+        self._stationary_elapsed = (
+            self._stationary_elapsed + dt if speed < self.stationary_threshold else 0.0
+        )
+        return self.phase

--- a/animation/runtime/hybrid_controller.py
+++ b/animation/runtime/hybrid_controller.py
@@ -1,0 +1,217 @@
+"""Safe, transport-agnostic fusion of walking targets and authored animation."""
+
+from __future__ import annotations
+
+import logging
+import importlib
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from .gait import GaitPhaseTracker, leg_animation_gain
+from .modes import ModeStateMachine, RobotMode
+from .policy import INIT_POS, WalkPolicy
+
+LOG = logging.getLogger(__name__)
+LEG_COUNT = 10
+
+
+def _duck_anim_dependencies() -> tuple[Any, Any, Any, Any]:
+    try:
+        package = importlib.import_module("duck_anim")
+    except ImportError as exc:
+        try:
+            package = importlib.import_module("animation.duck_anim")
+        except ImportError:
+            raise RuntimeError(
+                "duck_anim with loader, player, mixer, and safety modules is required."
+            ) from exc
+    try:
+        prefix = package.__name__
+        return (
+            importlib.import_module(f"{prefix}.loader").load_clip_dir,
+            importlib.import_module(f"{prefix}.mixer").LayeredMixer,
+            importlib.import_module(f"{prefix}.player").AnimationPlayer,
+            importlib.import_module(f"{prefix}.safety").JointSafetyLimiter,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "duck_anim with loader, player, mixer, and safety modules is required."
+        ) from exc
+
+
+class HybridController:
+    """Blend animation strictly downstream from base standing or walking control."""
+
+    def __init__(
+        self,
+        *,
+        policy: WalkPolicy | None = None,
+        clips_dir: str | Path = "animation/clips",
+        clips: Mapping[str, Any] | None = None,
+        mixer: Any | None = None,
+        safety_limiter: Any | None = None,
+        standing_pose: Sequence[float] = INIT_POS,
+        docked_pose: Sequence[float] | None = None,
+        max_additive_leg_offset: float = 0.15,
+        full_body_speed_threshold: float = 0.1,
+    ) -> None:
+        self.mode_machine = ModeStateMachine()
+        self.gait = GaitPhaseTracker()
+        self.policy = policy
+        self.standing_pose = self._pose(standing_pose, "standing_pose")
+        self.docked_pose = self._pose(
+            self.standing_pose if docked_pose is None else docked_pose, "docked_pose"
+        )
+        if max_additive_leg_offset < 0:
+            raise ValueError("max_additive_leg_offset must be non-negative")
+        self.max_additive_leg_offset = float(max_additive_leg_offset)
+        self.full_body_speed_threshold = float(full_body_speed_threshold)
+
+        if mixer is None or safety_limiter is None or clips is None:
+            load_clip_dir, LayeredMixer, _, JointSafetyLimiter = _duck_anim_dependencies()
+            mixer = mixer or LayeredMixer()
+            safety_limiter = safety_limiter or JointSafetyLimiter(dt=0.02)
+            clips = clips if clips is not None else self._load_clips(clips_dir, load_clip_dir)
+        self.mixer = mixer
+        self.safety_limiter = safety_limiter
+        self.clips = dict(clips)
+        self._last_output = self.standing_pose.copy()
+        self._group_weights = {"legs": 1.0, "head": 1.0, "antennas": 1.0}
+
+    @property
+    def mode(self) -> RobotMode:
+        return self.mode_machine.target_mode
+
+    @staticmethod
+    def _pose(values: Sequence[float], name: str) -> np.ndarray:
+        pose = np.asarray(values, dtype=np.float32).reshape(-1)
+        if pose.size != 16:
+            raise ValueError(f"{name} must contain 16 joint values")
+        return pose.copy()
+
+    @staticmethod
+    def _load_clips(path: str | Path, loader: Any) -> dict[str, Any]:
+        directory = Path(path)
+        if not directory.exists():
+            LOG.warning("Animation clip directory does not exist: %s", directory)
+            return {}
+        return loader(directory)
+
+    def set_mode(self, mode: RobotMode) -> bool:
+        return self.mode_machine.request(mode)
+
+    def emergency_stop(self) -> None:
+        self.mode_machine.request(RobotMode.EMERGENCY_STOP)
+        self.stop_all()
+
+    def _clip_has_legs(self, clip: Any) -> bool:
+        return any(
+            joint in {
+                "left_hip_yaw", "left_hip_roll", "left_hip_pitch", "left_knee", "left_ankle",
+                "right_hip_yaw", "right_hip_roll", "right_hip_pitch", "right_knee", "right_ankle",
+            }
+            for joint in clip.joints
+        )
+
+    def _clip_is_full_body(self, clip: Any) -> bool:
+        return self._clip_has_legs(clip) and len(clip.joints) > LEG_COUNT
+
+    def play(self, clip_name: str, **kwargs: Any) -> bool:
+        clip = self.clips.get(clip_name)
+        if clip is None:
+            LOG.warning("Unknown animation clip: %s", clip_name)
+            return False
+        if self.mode is RobotMode.DEMO_DOCK and self._clip_has_legs(clip):
+            LOG.warning("Refusing leg clip %s while docked", clip_name)
+            return False
+        commanded_velocity = np.asarray(kwargs.pop("commanded_velocity", (0.0, 0.0, 0.0)))
+        if self._clip_is_full_body(clip) and np.linalg.norm(commanded_velocity) > self.full_body_speed_threshold:
+            LOG.warning("Refusing full-body clip %s while moving", clip_name)
+            return False
+        _, _, AnimationPlayer, _ = _duck_anim_dependencies()
+        player = AnimationPlayer(clip, **kwargs)
+        self.mixer.add(player, name=clip_name)
+        return True
+
+    def play_additive(self, clip_name: str, **kwargs: Any) -> bool:
+        clip = self.clips.get(clip_name)
+        if clip is None or getattr(clip, "layer", None) != "additive":
+            LOG.warning("Clip %s is not an additive clip", clip_name)
+            return False
+        return self.play(clip_name, **kwargs)
+
+    def stop(self, clip_name: str) -> None:
+        self.mixer.remove(clip_name)
+
+    def stop_all(self) -> None:
+        self.mixer.clear()
+
+    def _base_pose(self, policy_obs: Sequence[float] | None) -> np.ndarray:
+        mode = self.mode
+        if mode in {RobotMode.WALK, RobotMode.HYBRID_WALK}:
+            if self.policy is None:
+                raise RuntimeError("WALK mode requires a WalkPolicy")
+            if policy_obs is None:
+                raise ValueError("WALK mode requires true measured policy_obs")
+            return self.policy.action_to_targets(self.policy.infer(policy_obs))
+        if mode is RobotMode.DEMO_DOCK:
+            return self.docked_pose.copy()
+        return self.standing_pose.copy()
+
+    def _set_group_weights(self, commanded_velocity: Sequence[float]) -> None:
+        dock_transition = (
+            self.mode_machine.transitioning
+            and (
+                self.mode_machine.mode is RobotMode.DEMO_DOCK
+                or self.mode_machine.target_mode is RobotMode.DEMO_DOCK
+            )
+        )
+        if self.mode is RobotMode.EMERGENCY_STOP:
+            weights = {"legs": 0.0, "head": 0.0, "antennas": 0.0}
+        else:
+            legs = 0.0 if self.mode is RobotMode.DEMO_DOCK or dock_transition else leg_animation_gain(self.mode, commanded_velocity)
+            weights = {"legs": legs, "head": 1.0, "antennas": 1.0}
+        self._group_weights = weights
+        for group, weight in weights.items():
+            self.mixer.set_group_weight(group, weight)
+
+    def _clamp_additive_legs(self, base: np.ndarray, mixed: np.ndarray) -> np.ndarray:
+        """Bound downstream leg deviations before final position/velocity safety."""
+        output = np.asarray(mixed, dtype=np.float32).copy()
+        offsets = np.clip(
+            output[:LEG_COUNT] - base[:LEG_COUNT],
+            -self.max_additive_leg_offset,
+            self.max_additive_leg_offset,
+        )
+        output[:LEG_COUNT] = base[:LEG_COUNT] + offsets
+        return output
+
+    def step(
+        self,
+        dt: float,
+        commanded_velocity: Sequence[float],
+        policy_obs: Sequence[float] | None = None,
+    ) -> np.ndarray:
+        """Return the final canonical 16-joint target array."""
+        self.mode_machine.update(dt)
+        self.gait.update(dt, commanded_velocity)
+        base = self._base_pose(policy_obs)
+        self._set_group_weights(commanded_velocity)
+        self.mixer.update(dt)
+        mixed = self._clamp_additive_legs(base, self.mixer.mix(base))
+        self._last_output = np.asarray(
+            self.safety_limiter.apply(mixed, self._last_output), dtype=np.float32
+        )
+        return self._last_output.copy()
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode.name,
+            "blend_alpha": self.mode_machine.blend_alpha,
+            "active_clips": list(getattr(self.mixer, "active_clips", [])),
+            "group_weights": dict(self._group_weights),
+            "clamped_joints": list(getattr(self.safety_limiter, "clamped_joints", [])),
+            "gait_phase": self.gait.phase,
+        }

--- a/animation/runtime/modes.py
+++ b/animation/runtime/modes.py
@@ -1,0 +1,105 @@
+"""Robot operating modes and their intentionally constrained transitions."""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class RobotMode(Enum):
+    IDLE = auto()
+    STAND = auto()
+    WALK = auto()
+    HYBRID_STAND = auto()
+    HYBRID_WALK = auto()
+    DEMO_DOCK = auto()
+    EMERGENCY_STOP = auto()
+
+
+_ALL_MODES = frozenset(RobotMode)
+_TRANSITIONS: dict[RobotMode, frozenset[RobotMode]] = {
+    RobotMode.IDLE: frozenset(
+        {RobotMode.STAND, RobotMode.DEMO_DOCK, RobotMode.EMERGENCY_STOP}
+    ),
+    RobotMode.STAND: frozenset(
+        {
+            RobotMode.IDLE,
+            RobotMode.WALK,
+            RobotMode.HYBRID_STAND,
+            RobotMode.DEMO_DOCK,
+            RobotMode.EMERGENCY_STOP,
+        }
+    ),
+    RobotMode.WALK: frozenset(
+        {RobotMode.STAND, RobotMode.HYBRID_WALK, RobotMode.EMERGENCY_STOP}
+    ),
+    RobotMode.HYBRID_STAND: frozenset(
+        {RobotMode.STAND, RobotMode.EMERGENCY_STOP}
+    ),
+    RobotMode.HYBRID_WALK: frozenset(
+        {RobotMode.WALK, RobotMode.STAND, RobotMode.EMERGENCY_STOP}
+    ),
+    RobotMode.DEMO_DOCK: frozenset(
+        {RobotMode.STAND, RobotMode.IDLE, RobotMode.EMERGENCY_STOP}
+    ),
+    RobotMode.EMERGENCY_STOP: frozenset({RobotMode.IDLE}),
+}
+
+
+class ModeStateMachine:
+    """Track mode transitions and a blend progress for downstream controllers."""
+
+    def __init__(
+        self,
+        initial_mode: RobotMode = RobotMode.IDLE,
+        default_duration: float = 0.3,
+        dock_duration: float = 0.8,
+    ) -> None:
+        if default_duration < 0 or dock_duration < 0:
+            raise ValueError("Transition durations must be non-negative")
+        self.mode = initial_mode
+        self.previous_mode = initial_mode
+        self.target_mode = initial_mode
+        self.default_duration = float(default_duration)
+        self.dock_duration = float(dock_duration)
+        self._elapsed = 0.0
+        self._duration = 0.0
+
+    @property
+    def transitioning(self) -> bool:
+        return self.mode != self.target_mode
+
+    @property
+    def blend_alpha(self) -> float:
+        if not self.transitioning or self._duration == 0:
+            return 1.0
+        return min(1.0, max(0.0, self._elapsed / self._duration))
+
+    def request(self, mode: RobotMode) -> bool:
+        """Start a legal transition, returning false without changing state otherwise."""
+        if mode == self.target_mode:
+            return True
+        if mode not in _TRANSITIONS[self.mode]:
+            return False
+        self.previous_mode = self.mode
+        self.target_mode = mode
+        self._elapsed = 0.0
+        self._duration = self._transition_duration(self.mode, mode)
+        if self._duration == 0:
+            self.mode = mode
+        return True
+
+    def update(self, dt: float) -> None:
+        if dt < 0:
+            raise ValueError("dt must be non-negative")
+        if not self.transitioning:
+            return
+        self._elapsed += dt
+        if self._elapsed >= self._duration:
+            self.mode = self.target_mode
+
+    def _transition_duration(self, source: RobotMode, target: RobotMode) -> float:
+        if target is RobotMode.EMERGENCY_STOP:
+            return 0.0
+        if source is RobotMode.DEMO_DOCK or target is RobotMode.DEMO_DOCK:
+            return self.dock_duration
+        return self.default_duration

--- a/animation/runtime/policy.py
+++ b/animation/runtime/policy.py
@@ -1,0 +1,89 @@
+"""ONNX walking-policy integration independent of robot transport."""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+INIT_POS = np.array(
+    [0.002, 0.053, -0.63, 1.368, -0.784, 0.0, 0.0, 0.0, 0.0, 0.0,
+     0.0, -0.003, -0.065, 0.635, 1.379, -0.796],
+    dtype=np.float32,
+)
+ACTION_SCALE = 0.25
+
+
+class WalkPolicy:
+    """Run the walking ONNX model and maintain its policy-owned state."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        action_scale: float = ACTION_SCALE,
+        init_pos: np.ndarray = INIT_POS,
+        session: object | None = None,
+    ) -> None:
+        if session is None:
+            try:
+                import onnxruntime as ort
+            except ImportError as exc:
+                raise RuntimeError(
+                    "onnxruntime is required for WalkPolicy; install it to use WALK modes."
+                ) from exc
+            session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+        self.session = session
+        self.input_name = session.get_inputs()[0].name
+        self.previous_action = np.zeros(16, dtype=np.float32)
+        self.action_scale = float(action_scale)
+        self.init_pos = np.asarray(init_pos, dtype=np.float32)
+        if self.init_pos.shape != (16,):
+            raise ValueError("init_pos must contain 16 joints")
+        shape = session.get_inputs()[0].shape
+        self.input_size = int(shape[-1]) if isinstance(shape[-1], int) else 74
+        if self.input_size < 56:
+            raise ValueError(f"Policy input has unsupported size {self.input_size}")
+        self._history: deque[np.ndarray] = deque(maxlen=max(0, self.input_size - 56))
+
+    def build_observation(self, measured_observation: Sequence[float]) -> np.ndarray:
+        """Build input with raw policy action feedback, never a blended target.
+
+        CRITICAL: ``previous_action`` is the policy's own raw ONNX action. Feeding
+        animation-blended targets back here makes the policy observe commands it
+        never issued, drifts its internal state, and can degrade gait into a fall.
+        Animation is strictly downstream of this policy input.
+        """
+        measured = np.asarray(measured_observation, dtype=np.float32).reshape(-1)
+        if measured.size == 56:
+            # Original observation layout ends in a 16-element previous-action term.
+            measured = measured.copy()
+            measured[37:53] = self.previous_action
+        if measured.size > self.input_size:
+            raise ValueError(f"Observation has {measured.size}, policy expects {self.input_size}")
+        tail = self.input_size - measured.size
+        history = np.concatenate(tuple(self._history), dtype=np.float32) if self._history else np.empty(0, dtype=np.float32)
+        if history.size < tail:
+            history = np.pad(history, (tail - history.size, 0))
+        return np.concatenate((measured, history[-tail:])).astype(np.float32)
+
+    def infer(self, observation: Sequence[float]) -> np.ndarray:
+        policy_input = self.build_observation(observation)
+        raw_action = np.asarray(
+            self.session.run(None, {self.input_name: policy_input[None, :]})[0],
+            dtype=np.float32,
+        ).reshape(-1)
+        if raw_action.size != 16:
+            raise ValueError(f"Policy returned {raw_action.size} actions; expected 16")
+        # Keep only the raw neural-policy output for the next policy observation.
+        self.previous_action = raw_action.copy()
+        self._history.append(policy_input.copy())
+        return raw_action
+
+    def action_to_targets(self, action: Sequence[float]) -> np.ndarray:
+        action = np.asarray(action, dtype=np.float32).reshape(-1)
+        if action.size != 16:
+            raise ValueError("action must contain 16 values")
+        return self.init_pos + action * self.action_scale

--- a/animation/runtime/tests/test_gait.py
+++ b/animation/runtime/tests/test_gait.py
@@ -1,0 +1,19 @@
+from animation.runtime.gait import GaitPhaseTracker, leg_animation_gain
+from animation.runtime.modes import RobotMode
+
+
+def test_leg_gain_is_stationary_one_and_monotonic() -> None:
+    speeds = [0.0, 0.05, 0.1, 0.2, 0.4, 1.0]
+    gains = [leg_animation_gain(RobotMode.HYBRID_WALK, (speed, 0, 0)) for speed in speeds]
+    assert gains[0] == 1.0
+    assert all(left >= right for left, right in zip(gains, gains[1:]))
+
+
+def test_stationary_requires_debounce() -> None:
+    tracker = GaitPhaseTracker(debounce_window=0.3)
+    tracker.update(0.29, (0, 0, 0))
+    assert not tracker.is_stationary
+    tracker.update(0.01, (0, 0, 0))
+    assert tracker.is_stationary
+    tracker.update(0.02, (1, 0, 0))
+    assert not tracker.is_stationary

--- a/animation/runtime/tests/test_hybrid_controller.py
+++ b/animation/runtime/tests/test_hybrid_controller.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+from animation.runtime.hybrid_controller import HybridController
+from animation.runtime.modes import RobotMode
+
+JOINT_LIMITS = np.asarray(
+    [
+        (-0.5235988, 0.5235988), (-0.4363323, 0.4363323),
+        (-1.2217305, 0.5235988), (-1.5707963, 1.5707963),
+        (-1.5707963, 1.5707963), (-0.5235988, 0.5235988),
+        (-0.4363323, 0.4363323), (-0.5235988, 1.2217305),
+        (-1.5707963, 1.5707963), (-1.5707963, 1.5707963),
+        (-0.3490659, 1.1344640), (-0.7853982, 0.7853982),
+        (-2.7925268, 2.7925268), (-0.5235988, 0.5235988),
+        (-1.5707963, 1.5707963), (-1.5707963, 1.5707963),
+    ],
+    dtype=np.float32,
+)
+
+
+class FakeMixer:
+    def __init__(self, offset: float = 0.0) -> None:
+        self.offset = offset
+        self.weights = {}
+        self.active_clips = []
+
+    def set_group_weight(self, group, weight):
+        self.weights[group] = weight
+
+    def update(self, _dt):
+        pass
+
+    def mix(self, base):
+        result = np.asarray(base, dtype=np.float32).copy()
+        result[:10] += self.offset
+        return result
+
+    def add(self, player, name=None):
+        self.active_clips.append(name)
+
+    def remove(self, name):
+        self.active_clips.remove(name)
+
+    def clear(self):
+        self.active_clips.clear()
+
+
+class FakeLimiter:
+    def __init__(self):
+        self.clamped_joints = []
+
+    def apply(self, target, _previous):
+        return np.clip(target, JOINT_LIMITS[:, 0], JOINT_LIMITS[:, 1])
+
+
+def controller(offset=0.0):
+    return HybridController(
+        clips={},
+        mixer=FakeMixer(offset),
+        safety_limiter=FakeLimiter(),
+        standing_pose=np.zeros(16),
+    )
+
+
+def test_demo_dock_forces_leg_weight_to_zero() -> None:
+    control = controller()
+    assert control.set_mode(RobotMode.DEMO_DOCK)
+    control.step(0.02, (0, 0, 0))
+    assert control.status()["group_weights"]["legs"] == 0.0
+
+
+def test_additive_leg_offsets_are_clamped_before_safety() -> None:
+    control = controller(offset=1.0)
+    output = control.step(0.02, (0, 0, 0))
+    assert np.allclose(output[:10], 0.15)
+
+
+def test_emergency_stop_zeroes_animation_authority() -> None:
+    control = controller()
+    control.emergency_stop()
+    control.step(0.02, (0, 0, 0))
+    assert control.status()["group_weights"] == {"legs": 0.0, "head": 0.0, "antennas": 0.0}
+
+
+def test_output_stays_within_joint_limits() -> None:
+    control = controller(offset=100.0)
+    output = control.step(0.02, (0, 0, 0))
+    assert np.all((JOINT_LIMITS[:, 0] <= output) & (output <= JOINT_LIMITS[:, 1]))

--- a/animation/runtime/tests/test_modes.py
+++ b/animation/runtime/tests/test_modes.py
@@ -1,0 +1,22 @@
+from animation.runtime.modes import ModeStateMachine, RobotMode
+
+
+def test_illegal_mode_transitions_are_rejected() -> None:
+    machine = ModeStateMachine()
+    assert not machine.request(RobotMode.HYBRID_WALK)
+    assert machine.mode is RobotMode.IDLE
+    assert machine.request(RobotMode.STAND)
+    machine.update(1.0)
+    assert machine.request(RobotMode.DEMO_DOCK)
+    machine.update(1.0)
+    assert not machine.request(RobotMode.WALK)
+
+
+def test_emergency_stop_is_reachable_from_every_mode() -> None:
+    for mode in RobotMode:
+        if mode is RobotMode.EMERGENCY_STOP:
+            continue
+        machine = ModeStateMachine(mode)
+        assert machine.request(RobotMode.EMERGENCY_STOP)
+        assert machine.target_mode is RobotMode.EMERGENCY_STOP
+        assert machine.mode is RobotMode.EMERGENCY_STOP

--- a/animation/runtime/tests/test_policy.py
+++ b/animation/runtime/tests/test_policy.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from animation.runtime.policy import WalkPolicy
+
+
+class FakeInput:
+    name = "obs"
+    shape = [1, 74]
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.input = None
+
+    def get_inputs(self):
+        return [FakeInput()]
+
+    def run(self, _outputs, inputs):
+        self.input = inputs["obs"].copy()
+        return [np.arange(16, dtype=np.float32)[None, :]]
+
+
+def test_previous_action_is_raw_policy_action_not_blended_output() -> None:
+    session = FakeSession()
+    policy = WalkPolicy("unused.onnx", session=session)
+    observation = np.zeros(56, dtype=np.float32)
+    raw_action = policy.infer(observation)
+    blended_output = policy.action_to_targets(raw_action) + 0.4
+
+    policy.infer(observation)
+
+    assert np.array_equal(session.input[0, 37:53], raw_action)
+    assert not np.array_equal(session.input[0, 37:53], blended_output)

--- a/experiments/v2/anim_mujoco_demo.py
+++ b/experiments/v2/anim_mujoco_demo.py
@@ -1,0 +1,162 @@
+"""Run the hybrid RL/animation controller against the Open Duck Mini MuJoCo scene."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from animation.runtime import HybridController, RobotMode, WalkPolicy
+
+
+def quat_rotate_inverse(q: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Rotate vector ``v`` by the inverse of xyzw quaternion ``q``."""
+    q_w = q[-1]
+    q_vec = q[:3]
+    return v * (2.0 * q_w**2 - 1.0) - np.cross(q_vec, v) * q_w * 2.0 + q_vec * np.dot(q_vec, v) * 2.0
+
+
+def feet_contacts(model, data, mujoco) -> list[float]:
+    contacts = [False, False]
+    for index in range(data.ncon):
+        contact = data.contact[index]
+        first = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom1) or ""
+        second = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom2) or ""
+        names = {first, second}
+        contacts[0] |= "foot_assembly" in names and "floor" in names
+        contacts[1] |= "foot_assembly_2" in names and "floor" in names
+    return [float(contact) for contact in contacts]
+
+
+def observation(model, data, mujoco, commands: np.ndarray) -> np.ndarray:
+    base_quat_wxyz = data.qpos[3:7].copy()
+    base_quat_xyzw = np.array(
+        [base_quat_wxyz[1], base_quat_wxyz[2], base_quat_wxyz[3], base_quat_wxyz[0]]
+    )
+    return np.concatenate(
+        (
+            quat_rotate_inverse(base_quat_xyzw, np.array([0.0, 0.0, -1.0])),
+            data.qpos[7:23].copy(),
+            data.qvel[6:22].copy(),
+            feet_contacts(model, data, mujoco),
+            np.zeros(16),  # WalkPolicy replaces this with its raw previous action.
+            commands,
+        )
+    ).astype(np.float32)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--onnx_model_path", default="BEST_WALK_ONNX_2.onnx")
+    parser.add_argument("--clips", default="animation/clips")
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--duration", type=float, default=10.0)
+    parser.add_argument("--mode", choices=("stand", "walk", "hybrid-stand", "hybrid-walk", "dock"), default="stand")
+    parser.add_argument("--play", action="append", default=[], metavar="CLIP_NAME")
+    parser.add_argument("--vx", type=float, default=0.0)
+    parser.add_argument("--vy", type=float, default=0.0)
+    parser.add_argument("--wz", type=float, default=0.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        import mujoco
+    except ImportError:
+        print("MuJoCo is required: install with `pip install mujoco`.", file=sys.stderr)
+        return 2
+    try:
+        import onnxruntime  # noqa: F401 - WalkPolicy gives the actionable error otherwise.
+    except ImportError:
+        print("onnxruntime is required: install with `pip install onnxruntime`.", file=sys.stderr)
+        return 2
+
+    root = REPOSITORY_ROOT
+    model_path = Path(args.onnx_model_path)
+    if not model_path.is_absolute():
+        model_path = root / model_path
+    if not model_path.is_file():
+        print(f"ONNX model not found: {model_path}", file=sys.stderr)
+        return 2
+    scene_path = root / "mini_bdx/robots/open_duck_mini_v2/scene.xml"
+    model = mujoco.MjModel.from_xml_path(str(scene_path))
+    model.opt.timestep = 0.005
+    data = mujoco.MjData(model)
+    policy = WalkPolicy(model_path)
+    try:
+        controller = HybridController(policy=policy, clips_dir=root / args.clips)
+    except RuntimeError as exc:
+        print(f"Animation runtime unavailable: {exc}", file=sys.stderr)
+        return 2
+
+    modes = {
+        "stand": RobotMode.STAND,
+        "walk": RobotMode.WALK,
+        "hybrid-stand": RobotMode.HYBRID_STAND,
+        "hybrid-walk": RobotMode.HYBRID_WALK,
+        "dock": RobotMode.DEMO_DOCK,
+    }
+    controller.set_mode(RobotMode.STAND)
+    controller.mode_machine.update(1.0)
+    if modes[args.mode] is not RobotMode.STAND:
+        controller.set_mode(modes[args.mode])
+        controller.mode_machine.update(1.0)
+    data.qpos[7:23] = controller.standing_pose
+    data.ctrl[:16] = controller.standing_pose
+    commands = np.array((args.vx, args.vy, args.wz), dtype=np.float32)
+    for clip_name in args.play:
+        if not controller.play(clip_name, commanded_velocity=commands):
+            print(f"Could not start clip: {clip_name}", file=sys.stderr)
+            return 2
+    max_joint_deviation = 0.0
+    safety_clamped = False
+    max_tilt = 0.0
+    control_steps = max(1, round(args.duration / 0.02))
+
+    viewer = None
+    if not args.headless:
+        import mujoco.viewer
+        viewer = mujoco.viewer.launch_passive(model, data, show_left_ui=False, show_right_ui=False)
+        print("Use --mode, --play CLIP_NAME, --vx, --vy, and --wz to configure this run.")
+    try:
+        for _ in range(control_steps):
+            if viewer is not None and not viewer.is_running():
+                break
+            target = controller.step(0.02, commands, observation(model, data, mujoco, commands))
+            data.ctrl[:16] = target
+            max_joint_deviation = max(max_joint_deviation, float(np.max(np.abs(target - controller.standing_pose))))
+            safety_clamped |= bool(controller.status()["clamped_joints"])
+            for _ in range(4):
+                mujoco.mj_step(model, data)
+            up = quat_rotate_inverse(
+                np.array([data.qpos[4], data.qpos[5], data.qpos[6], data.qpos[3]]),
+                np.array([0.0, 0.0, 1.0]),
+            )
+            max_tilt = max(max_tilt, float(np.arccos(np.clip(up[2], -1.0, 1.0))))
+            if viewer is not None:
+                viewer.sync()
+                time.sleep(max(0.0, 0.02 - model.opt.timestep * 4))
+    finally:
+        if viewer is not None:
+            viewer.close()
+
+    upright = max_tilt < 1.0 and data.qpos[2] > 0.08
+    print(
+        "summary "
+        f"stayed_upright={upright} "
+        f"max_joint_deviation={max_joint_deviation:.4f} "
+        f"safety_clamping={safety_clamped}"
+    )
+    return 0 if upright else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a transport-independent `HybridController` that fuses standing/RL walking targets with downstream animation layers and final joint safety limiting.
- Adds gait phase tracking, constrained mode transitions, ONNX policy wrapping, focused pytest coverage, and a 50 Hz MuJoCo harness with headless regression reporting.

## Layering and safety
The controller creates the base target from the stand pose or RL policy using true measured state, then updates/mixes animation, gates leg authority based on commanded speed, bounds leg offsets to 0.15 rad, and applies the safety limiter last. Large leg offsets at speed can tip the duck, so leg animation authority smoothly declines to a floor while walking and is exactly zero in or transitioning to/from dock mode.

## Policy feedback invariant
`previous_action` fed to ONNX is always the policy's own raw action, never animation-blended joint targets. Animation remains strictly downstream; feeding blended output back would make the policy observe commands it never made and destabilize gait.

## Validation
`python -m pytest animation/runtime/tests -q` passes (9 tests). MuJoCo and onnxruntime installed cleanly. The full harness run waits on workstream A's `duck_anim.player`, `mixer`, and `safety` modules; until then it exits with a clear dependency message rather than silently running without animation safety.